### PR TITLE
fix(*): crash when pluginModel == nil

### DIFF
--- a/Sport1Player.podspec
+++ b/Sport1Player.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Sport1Player"
-  s.version          = '0.1.0'
+  s.version          = '1.0.1'
   s.summary          = "Sport1Player"
   s.description      = <<-DESC
                         Player for Sport1, based off JWPlayer.
@@ -22,7 +22,8 @@ Pod::Spec.new do |s|
 
   s.xcconfig =  { 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
                   'ENABLE_BITCODE' => 'YES',
-                  'OTHER_CFLAGS'  => '-fembed-bitcode'
+                  'OTHER_CFLAGS'  => '-fembed-bitcode',
+                  'OTHER_LDFLAGS' => '$(inherited) -framework "JWPlayer_iOS_SDK"'
                   }
 
   s.dependency 'ZappPlugins'

--- a/Sport1Player.xcodeproj/project.pbxproj
+++ b/Sport1Player.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -79,7 +79,6 @@
 				27FFD671506CEF4AB398DF6A /* Pods-Sport1PlayerTests.debug.xcconfig */,
 				05CCA15B2245B0A449FE0614 /* Pods-Sport1PlayerTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};

--- a/Sport1Player/Info.plist
+++ b/Sport1Player/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -16,7 +16,7 @@
 static NSString *const kTrackingInfoKey = @"tracking_info";
 static NSString *const kAgeRatingKey = @"age_rating";
 static NSString *const kPlayableItemsKey = @"playable_items";
-static NSString *const kPluginName = @"age_verification_plugin_id";
+static NSString *const kPluginName = @"pin_validation_plugin_id";
 static int kWatershedAge = 16;
 
 @implementation Sport1PlayerAdapter
@@ -42,7 +42,7 @@ static int kWatershedAge = 16;
     
     return instance;
 }
-
+#pragma mark - Add Player
 - (void)pluggablePlayerAddInline:(UIViewController * _Nonnull)rootViewController container:(UIView * _Nonnull)container {
     [self pluggablePlayerAddInline:rootViewController
                          container:container
@@ -87,7 +87,7 @@ static int kWatershedAge = 16;
               playerConfiguration:configuration];
     }
 }
-
+#pragma mark - Present Player
 - (void)presentPlayerFullScreen:(UIViewController * _Nonnull)rootViewController configuration:(ZPPlayerConfiguration * _Nullable)configuration {
     [self presentPlayerFullScreen:rootViewController configuration:configuration completion:nil];
 }
@@ -131,7 +131,7 @@ static int kWatershedAge = 16;
               playerConfiguration:configuration];
     }
 }
-
+#pragma mark - Login & Pin
 - (void)handleUserComply:(BOOL)isUserComply
              loginPlugin:(NSObject<ZPLoginProviderUserDataProtocol> *)plugin
       rootViewController:(UIViewController *)rootViewController
@@ -206,6 +206,11 @@ static int kWatershedAge = 16;
 
 -(void)presentPinOn:(UIViewController*)rootViewController container:(UIView*)container playerConfiguration:(ZPPlayerConfiguration * _Nullable)configuration {
     ZPPluginModel *pluginModel = [ZPPluginManager pluginModelById:self.configurationJSON[kPluginName]];
+    
+    if (pluginModel == nil) {
+        return;
+    }
+    
     Class pluginClass = [ZPPluginManager adapterClass:pluginModel];
     if ([pluginClass conformsToProtocol:@protocol(ZPAdapterProtocol)]) {
         NSObject <PluginPresenterProtocol> *plugin = [[pluginClass alloc] initWithConfigurationJSON:[pluginModel configurationJSON]];

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -1,7 +1,7 @@
 {
   "api": {
     "require_startup_execution": false,
-    "class_name": "Sport1Player",
+    "class_name": "Sport1PlayerAdapter",
     "modules": [
 
     ]
@@ -12,15 +12,15 @@
   "platform": "ios",
   "author_name": "Oliver Stowell",
   "author_email": "o.stowell@applicaster.co.uk",
-  "manifest_version": "1.0.0",
+  "manifest_version": "1.0.1",
   "name": "Sport1 Player",
   "description": "Sport1 wrapper for JWPlayer",
   "type": "player",
   "screen": true,
   "identifier": "sport1player",
   "ui_builder_support": true,
-  "dependency_name": "Sport1Player-iOS",
-  "dependency_version": "1.0.0",
+  "dependency_name": "Sport1Player",
+  "dependency_version": "1.0.1",
   "whitelisted_account_ids": [
     "5d1b6753564117000de4bb60"
   ],
@@ -31,8 +31,8 @@
   "custom_configuration_fields": [
     {
       "type": "text",
-      "key": "age_verification_plugin_id",
-      "tooltip_text": "The identifier for the age verification plugin to be used."
+      "key": "pin_validation_plugin_id",
+      "tooltip_text": "The identifier for the pin validation plugin to be used."
     },
     {
         "type": "text",


### PR DESCRIPTION
## Description:

Plugin caused the app to crash when `pluginModel` defined by `pin_validation_plugin_id` was nil.

## Known Issues:

### Checklist for this pull request
- [x] PR is scoped to one task
- [ ] Tests included

- One of:
  - [x] The PR is not making any UI change
  - [ ] The PR is making a UI change
    - [ ] Screenshots included

 ## QA:
  - Required test cases:
  - Which apps this change/fix should be tested on:

Thank you!