### PR TITLE
fix(*): Livestream Pin Validation

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,8 +27,8 @@ PODS:
     - FBSDKCoreKit (~> 5.0)
   - FBSDKShareKit (5.2.3):
     - FBSDKCoreKit (~> 5.0)
-  - JWPlayer-SDK (3.6.1)
-  - JWPlayerPlugin (3.2.1):
+  - JWPlayer-SDK (3.6.2)
+  - JWPlayerPlugin (3.2.3):
     - ApplicasterSDK
     - JWPlayer-SDK (~> 3.0)
     - ZappLoginPluginsSDK
@@ -43,10 +43,10 @@ PODS:
     - ZappPlugins
   - ZappGeneralPluginsSDK (8.1.0):
     - ZappPlugins
-  - ZappLoginPluginsSDK (8.0.1):
+  - ZappLoginPluginsSDK (8.0.2):
     - Alamofire
     - ZappPlugins
-  - ZappPlugins (9.2.1)
+  - ZappPlugins (9.2.4)
   - ZappPushPluginsSDK (8.0.2):
     - ZappPlugins
 
@@ -86,8 +86,8 @@ SPEC CHECKSUMS:
   FBSDKCoreKit: 5154c35d9058fd7dfa0445ba19e194c4b172fc32
   FBSDKLoginKit: dc98b6bf12334f1a42f28d0457fffc9aa3d1eca5
   FBSDKShareKit: 6f9c622f9a5d051f43f2dab6f753d5198422b89c
-  JWPlayer-SDK: 23169dc5ebbf9e0f35ef470b4634f5fc85394596
-  JWPlayerPlugin: 5868633ab97036f3b132bc636faeffc25b15c545
+  JWPlayer-SDK: c99b17eb4bda08626569ff91c82caa30bc077e58
+  JWPlayerPlugin: 52cd52bf3de88bc55741b07dfb795649b7de8f21
   PluginPresenter: 1b3d0234c164216dae92b6cd81e79521b929adaa
   SSZipArchive: 1e8e53dcb11bca3ded4738958dc49fc467320a14
   TTTAttributedLabel: f8c7f1dbc7b8f7168e23e8b4764dda2e3b74aae8
@@ -95,8 +95,8 @@ SPEC CHECKSUMS:
   TwitterKit: 5e4f41d70b9abdb41df5467f52d7aa2c0fd26ebb
   ZappAnalyticsPluginsSDK: 6f8edcddc12ae4001098a3fa6fe87e6fe1a013bd
   ZappGeneralPluginsSDK: 7e91f6030d9f1b81b4781e823b0197bfad351bde
-  ZappLoginPluginsSDK: d3205f72e2fa2ddb24d2ba240591f41fbb8644d8
-  ZappPlugins: ddb6f77dfafaff23ec09675fedd94d0872b5011f
+  ZappLoginPluginsSDK: 7afb61fa738f1f73666a8250bd14b5dda8cc8f87
+  ZappPlugins: 054b44992825289d362cf5543ff7ce28e48b346f
   ZappPushPluginsSDK: 2062e2487f3ac877c0ab1a807d1a7f8d357bd333
 
 PODFILE CHECKSUM: bd13c32e3cec6c1325630eeff1bd6c7f57df6d91

--- a/Sport1Player.podspec
+++ b/Sport1Player.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Sport1Player"
-  s.version          = '1.0.1'
+  s.version          = '1.1.0'
   s.summary          = "Sport1Player"
   s.description      = <<-DESC
                         Player for Sport1, based off JWPlayer.

--- a/Sport1Player.xcodeproj/project.pbxproj
+++ b/Sport1Player.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		5280B5D02316A2C40095CFBF /* Sport1PlayerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Sport1PlayerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5280B5D52316A2C40095CFBF /* Sport1PlayerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Sport1PlayerTests.m; sourceTree = "<group>"; };
 		5280B5D72316A2C40095CFBF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		528F3B6A232AA65400438808 /* JWPlayerViewController+Public.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "JWPlayerViewController+Public.h"; sourceTree = "<group>"; };
 		529D8E652316BF780091A875 /* Sport1PlayerAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Sport1PlayerAdapter.h; sourceTree = "<group>"; };
 		529D8E662316BF780091A875 /* Sport1PlayerAdapter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Sport1PlayerAdapter.m; sourceTree = "<group>"; };
 		52B2BB5D2319279A00842E2A /* ZappJWPlayer+Public.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ZappJWPlayer+Public.h"; sourceTree = "<group>"; };
@@ -107,6 +108,7 @@
 			children = (
 				5280B5CA2316A2C30095CFBF /* Sport1Player.h */,
 				52B2BB5D2319279A00842E2A /* ZappJWPlayer+Public.h */,
+				528F3B6A232AA65400438808 /* JWPlayerViewController+Public.h */,
 				529D8E652316BF780091A875 /* Sport1PlayerAdapter.h */,
 				529D8E662316BF780091A875 /* Sport1PlayerAdapter.m */,
 				5221B5162319330A006DD39B /* Sport1PlayerLivestreamAge.h */,

--- a/Sport1Player/Info.plist
+++ b/Sport1Player/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sport1Player/JWPlayerViewController+Public.h
+++ b/Sport1Player/JWPlayerViewController+Public.h
@@ -1,0 +1,20 @@
+//
+//  JWPlayerViewController+Public.h
+//  Sport1Player
+//
+//  Created by Oliver Stowell on 12/09/2019.
+//  Copyright © 2019 Applicaster Ltd. All rights reserved.
+//
+
+#ifndef JWPlayerViewController_Public_h
+#define JWPlayerViewController_Public_h
+
+#import <JWPlayerPlugin/JWPlayerViewController.h>
+
+@interface JWPlayerViewController (Public)
+
+- (void)dismiss:(NSObject *)sender;
+
+@end
+
+#endif /* JWPlayerViewController_Public_h */

--- a/Sport1Player/Sport1PlayerAdapter.h
+++ b/Sport1Player/Sport1PlayerAdapter.h
@@ -13,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface Sport1PlayerAdapter : ZappJWPlayerAdapter
 
+-(void)shouldPresentPin;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -12,6 +12,7 @@
 #import "Sport1PlayerAdapter.h"
 #import <JWPlayer_iOS_SDK/JWPlayerController.h>
 #import "Sport1PlayerLivestreamAge.h"
+#import "JWPlayerViewController+Public.h"
 
 static NSString *const kTrackingInfoKey = @"tracking_info";
 static NSString *const kAgeRatingKey = @"age_rating";
@@ -21,6 +22,8 @@ static int kWatershedAge = 16;
 
 @interface Sport1PlayerAdapter ()
 @property (nonatomic) Sport1PlayerLivestreamPin *livestreamPinValidation;
+@property (nonatomic) UIView * container;
+@property (nonatomic) ZPPlayerConfiguration * playerConfiguration;
 @end
 
 @implementation Sport1PlayerAdapter
@@ -42,19 +45,33 @@ static int kWatershedAge = 16;
     instance.currentPlayableItem = items.firstObject;
     instance.currentPlayableItems = items;
     
-    self.livestreamPinValidation = [[Sport1PlayerLivestreamPin alloc] initWithConfigurationJSON:configurationJSON
-                                                                           currentPlayerAdapter:instance];
-    
     return instance;
 }
+#pragma mark - Livestream
+-(void)createLivestreamPinCheck {
+    self.livestreamPinValidation = [[Sport1PlayerLivestreamPin alloc] initWithConfigurationJSON:self.configurationJSON
+                                                                           currentPlayerAdapter:self];
+}
+
+-(void)setContainer:(UIView*)container andPlayerConfiguration:(ZPPlayerConfiguration*)playerConfiguration {
+    self.container = container;
+    self.playerConfiguration = playerConfiguration;
+}
+
 #pragma mark - Add Player
 - (void)pluggablePlayerAddInline:(UIViewController * _Nonnull)rootViewController container:(UIView * _Nonnull)container {
+    [self createLivestreamPinCheck];
+    [self setContainer:container
+andPlayerConfiguration:nil];
     [self pluggablePlayerAddInline:rootViewController
                          container:container
                      configuration:nil];
 }
 
 - (void)pluggablePlayerAddInline:(UIViewController *)rootViewController container:(UIView *)container configuration:(ZPPlayerConfiguration *)configuration {
+    [self createLivestreamPinCheck];
+    [self setContainer:container
+andPlayerConfiguration:configuration];
     if ([self.currentPlayableItem isFree] == NO) {
         NSObject<ZPLoginProviderUserDataProtocol> *loginPlugin = [[ZPLoginManager sharedInstance] createWithUserData];
         NSDictionary *extensions = [NSDictionary dictionaryWithObject:self.currentPlayableItems
@@ -94,10 +111,16 @@ static int kWatershedAge = 16;
 }
 #pragma mark - Present Player
 - (void)presentPlayerFullScreen:(UIViewController * _Nonnull)rootViewController configuration:(ZPPlayerConfiguration * _Nullable)configuration {
+    [self createLivestreamPinCheck];
+    [self setContainer:nil
+andPlayerConfiguration:configuration];
     [self presentPlayerFullScreen:rootViewController configuration:configuration completion:nil];
 }
 
 - (void)presentPlayerFullScreen:(UIViewController *)rootViewController configuration:(ZPPlayerConfiguration *)configuration completion:(void (^)(void))completion {
+    [self createLivestreamPinCheck];
+    [self setContainer:nil
+andPlayerConfiguration:configuration];
     if ([self.currentPlayableItem isFree] == NO) {
         NSObject<ZPLoginProviderUserDataProtocol> *loginPlugin = [[ZPLoginManager sharedInstance] createWithUserData];
         NSDictionary *extensions = [NSDictionary dictionaryWithObject:self.currentPlayableItems
@@ -173,7 +196,8 @@ static int kWatershedAge = 16;
         if ([self.livestreamPinValidation shouldDisplayPin]) {
             [self presentPinOn:rootViewController
                      container:container
-           playerConfiguration:configuration];
+           playerConfiguration:configuration
+             fromLivestreamPin:NO];
         } else {
             if (container == nil) {
                 [super playFullScreen:rootViewController
@@ -194,7 +218,8 @@ static int kWatershedAge = 16;
     if (ageRating.intValue >= kWatershedAge) {
         [self presentPinOn:rootViewController
                  container:container
-       playerConfiguration:configuration];
+       playerConfiguration:configuration
+         fromLivestreamPin:NO];
     } else {
         if (container == nil) {
             [super playFullScreen:rootViewController
@@ -209,10 +234,12 @@ static int kWatershedAge = 16;
     }
 }
 
--(void)presentPinOn:(UIViewController*)rootViewController container:(UIView*)container playerConfiguration:(ZPPlayerConfiguration * _Nullable)configuration {
+-(void)presentPinOn:(UIViewController*)rootViewController container:(UIView*)container playerConfiguration:(ZPPlayerConfiguration * _Nullable)configuration fromLivestreamPin:(BOOL)fromLivestreamPin {
     ZPPluginModel *pluginModel = [ZPPluginManager pluginModelById:self.configurationJSON[kPluginName]];
     
     if (pluginModel == nil) {
+        //currently this fails without warning & doesn't display player.
+        self.livestreamPinValidation = nil;
         return;
     }
     
@@ -223,18 +250,39 @@ static int kWatershedAge = 16;
         if ([plugin conformsToProtocol:@protocol(PluginPresenterProtocol)]) {
             [plugin presentPluginWithParentViewController:rootViewController
                                                 extraData:nil completion:^(BOOL success, id _Nullable data) {
-                                                    if (success && container == nil) {
+                                                    if (success && container == nil && !fromLivestreamPin) {
                                                         [super playFullScreen:rootViewController
                                                                 configuration:configuration
                                                                    completion:nil];
-                                                    } else if (success) {
+                                                    } else if (success && !fromLivestreamPin) {
                                                         [super playInline:rootViewController
                                                                 container:container
                                                             configuration:configuration
                                                                completion:nil];
+                                                    } else if (!success) {
+                                                        [self.playerViewController dismiss:nil];
+                                                        self.livestreamPinValidation = nil;
+                                                        self.container = nil;
+                                                        self.playerConfiguration = nil;
                                                     }
                                                 }];
         }
+    }
+}
+#pragma mark - Livestream Pin Presentation
+-(void)shouldPresentPin {
+    NSDictionary *trackingInfo = self.currentPlayableItem.extensionsDictionary[kTrackingInfoKey];
+    
+    if (![trackingInfo.allKeys containsObject:kAgeRatingKey]) {
+        [self.livestreamPinValidation updateLivestreamAgeData];
+        
+        if ([self.livestreamPinValidation shouldDisplayPin]) {
+            [self presentPinOn:self.playerViewController
+                     container:self.container
+           playerConfiguration:self.playerConfiguration
+             fromLivestreamPin:YES];
+        }
+        return;
     }
 }
 

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -19,7 +19,12 @@ static NSString *const kPlayableItemsKey = @"playable_items";
 static NSString *const kPluginName = @"age_verification_plugin_id";
 static int kWatershedAge = 16;
 
+@interface Sport1PlayerAdapter ()
+@property (nonatomic) Sport1PlayerLivestreamPin *livestreamPinValidation;
+@end
+
 @implementation Sport1PlayerAdapter
+@synthesize livestreamPinValidation = _livestreamPinValidation;
 
 + (id<ZPPlayerProtocol>)pluggablePlayerInitWithPlayableItems:(NSArray<id<ZPPlayable>> *)items configurationJSON:(NSDictionary *)configurationJSON {
     NSString *playerKey = configurationJSON[@"playerKey"];
@@ -37,8 +42,8 @@ static int kWatershedAge = 16;
     instance.currentPlayableItem = items.firstObject;
     instance.currentPlayableItems = items;
     
-    [[Sport1PlayerLivestreamAge sharedManager] setConfigurationJSON:configurationJSON];
-    [[Sport1PlayerLivestreamAge sharedManager] setCurrentPlayerAdapter:instance];
+    self.livestreamPinValidation = [[Sport1PlayerLivestreamPin alloc] initWithConfigurationJSON:configurationJSON
+                                                                           currentPlayerAdapter:instance];
     
     return instance;
 }
@@ -163,9 +168,9 @@ static int kWatershedAge = 16;
     NSDictionary *trackingInfo = currentPlayableItem.extensionsDictionary[kTrackingInfoKey];
     
     if (![trackingInfo.allKeys containsObject:kAgeRatingKey]) {
-        [[Sport1PlayerLivestreamAge sharedManager] updateLivestreamAgeData];
+        [self.livestreamPinValidation updateLivestreamAgeData];
         
-        if ([[Sport1PlayerLivestreamAge sharedManager] shouldDisplayPin]) {
+        if ([self.livestreamPinValidation shouldDisplayPin]) {
             [self presentPinOn:rootViewController
                      container:container
            playerConfiguration:configuration];

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -21,13 +21,12 @@ static NSString *const kPluginName = @"pin_validation_plugin_id";
 static int kWatershedAge = 16;
 
 @interface Sport1PlayerAdapter ()
-@property (nonatomic) Sport1PlayerLivestreamPin *livestreamPinValidation;
-@property (nonatomic) UIView * container;
-@property (nonatomic) ZPPlayerConfiguration * playerConfiguration;
+@property (nonatomic, strong) Sport1PlayerLivestreamPin *livestreamPinValidation;
+@property (nonatomic, weak) UIView * container;
+@property (nonatomic, strong) ZPPlayerConfiguration * playerConfiguration;
 @end
 
 @implementation Sport1PlayerAdapter
-@synthesize livestreamPinValidation = _livestreamPinValidation;
 
 + (id<ZPPlayerProtocol>)pluggablePlayerInitWithPlayableItems:(NSArray<id<ZPPlayable>> *)items configurationJSON:(NSDictionary *)configurationJSON {
     NSString *playerKey = configurationJSON[@"playerKey"];

--- a/Sport1Player/Sport1PlayerLivestreamAge.h
+++ b/Sport1Player/Sport1PlayerLivestreamAge.h
@@ -11,13 +11,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface Sport1PlayerLivestreamAge : NSObject
+@interface Sport1PlayerLivestreamPin : NSObject
 
 @property (nonatomic, weak) Sport1PlayerAdapter *currentPlayerAdapter;
 
-+(id)sharedManager;
--(void)setConfigurationJSON:(NSDictionary *)configurationJSON;
--(void)setCurrentPlayerController:(Sport1PlayerAdapter * _Nullable)currentPlayerAdapter;
+-(instancetype)initWithConfigurationJSON:(NSDictionary*)configurationJSON currentPlayerAdapter:(Sport1PlayerAdapter* _Nullable)currentPlayerAdapter;
 -(void)updateLivestreamAgeData;
 -(BOOL)shouldDisplayPin;
 

--- a/Sport1Player/Sport1PlayerLivestreamAge.m
+++ b/Sport1Player/Sport1PlayerLivestreamAge.m
@@ -15,7 +15,7 @@ static NSString *const kEPG = @"epg";
 static NSString *const kLivestreamEnd = @"end";
 static NSString *const kLivestreamStart = @"start";
 
-@interface Sport1PlayerLivestreamAge ()
+@interface Sport1PlayerLivestreamPin ()
 @property (nonatomic, strong) NSTimer *timer;
 @property (nonatomic, strong) NSString *livestreamURL;
 @property (nonatomic) NSDate *ageRestrictionEnd;
@@ -57,14 +57,14 @@ static NSString *const kLivestreamStart = @"start";
                 return;
             }
         }
-        __block typeof(self) blockSelf = self;
-        self.timer = [[NSTimer alloc] initWithFireDate:self.livestreamEnd
+        __weak Sport1PlayerLivestreamPin *weakSelf = self;
+        self.timer = [[NSTimer alloc] initWithFireDate:weakSelf.livestreamEnd
                                               interval:0
                                                repeats:NO
                                                  block:^(NSTimer * _Nonnull timer) {
-                                                     [blockSelf updateLivestreamAgeData];
+                                                     [weakSelf.currentPlayerAdapter shouldPresentPin];
                                                  }];
-        [[NSRunLoop mainRunLoop] addTimer:self.timer
+        [[NSRunLoop mainRunLoop] addTimer:weakSelf.timer
                                      forMode:NSRunLoopCommonModes];
     }
 }

--- a/Sport1Player/Sport1PlayerLivestreamAge.m
+++ b/Sport1Player/Sport1PlayerLivestreamAge.m
@@ -64,7 +64,7 @@ static NSString *const kLivestreamStart = @"start";
                                                  block:^(NSTimer * _Nonnull timer) {
                                                      [weakSelf.currentPlayerAdapter shouldPresentPin];
                                                  }];
-        [[NSRunLoop mainRunLoop] addTimer:weakSelf.timer
+        [[NSRunLoop mainRunLoop] addTimer:self.timer
                                      forMode:NSRunLoopCommonModes];
     }
 }

--- a/Sport1Player/Sport1PlayerLivestreamAge.m
+++ b/Sport1Player/Sport1PlayerLivestreamAge.m
@@ -23,20 +23,14 @@ static NSString *const kLivestreamStart = @"start";
 @property (nonatomic) NSDate *livestreamEnd;
 @end
 
-@implementation Sport1PlayerLivestreamAge
+@implementation Sport1PlayerLivestreamPin
 
-+ (id)sharedManager {
-    static Sport1PlayerLivestreamAge *sharedMyManager = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedMyManager = [[self alloc] init];
-    });
-    return sharedMyManager;
-}
-
-- (void)setConfigurationJSON:(NSDictionary *)configurationJSON
-{
-    self.livestreamURL = configurationJSON[kLivestreamURL];
+-(instancetype)initWithConfigurationJSON:(NSDictionary *)configurationJSON currentPlayerAdapter:(Sport1PlayerAdapter *)currentPlayerAdapter {
+    if (self = [super init]) {
+        self.livestreamURL = configurationJSON[kLivestreamURL];
+        self.currentPlayerAdapter = currentPlayerAdapter;
+    }
+    return self;
 }
 
 - (void)updateLivestreamAgeData {

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -12,7 +12,7 @@
   "platform": "ios",
   "author_name": "Oliver Stowell",
   "author_email": "o.stowell@applicaster.co.uk",
-  "manifest_version": "1.0.1",
+  "manifest_version": "1.1.0",
   "name": "Sport1 Player",
   "description": "Sport1 wrapper for JWPlayer",
   "type": "player",
@@ -20,7 +20,7 @@
   "identifier": "sport1player",
   "ui_builder_support": true,
   "dependency_name": "Sport1Player",
-  "dependency_version": "1.0.1",
+  "dependency_version": "1.1.0",
   "whitelisted_account_ids": [
     "5d1b6753564117000de4bb60"
   ],


### PR DESCRIPTION
## Description:

Pin validation is now launched when the livestream ends and requires validation. Closing the validation screen closes the player.

## Known Issues:

### Checklist for this pull request
- [x] PR is scoped to one task
- [ ] Tests included

- One of:
  - [x] The PR is not making any UI change
  - [ ] The PR is making a UI change
    - [ ] Screenshots included

 ## QA:
  - Required test cases:
  - Which apps this change/fix should be tested on:

Thank you!