### PR TITLE
fix(*): Correcting the age rating key & logic

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Alamofire (4.8.2)
-  - ApplicasterSDK (10.2.1):
+  - ApplicasterSDK (10.4.1):
     - Alamofire (= 4.8.2)
     - CocoaLumberjack/Swift (= 3.5.3)
     - FBSDKCoreKit (= 5.2.3)
@@ -27,7 +27,7 @@ PODS:
     - FBSDKCoreKit (~> 5.0)
   - FBSDKShareKit (5.2.3):
     - FBSDKCoreKit (~> 5.0)
-  - JWPlayer-SDK (3.6.2)
+  - JWPlayer-SDK (3.6.3)
   - JWPlayerPlugin (3.2.3):
     - ApplicasterSDK
     - JWPlayer-SDK (~> 3.0)
@@ -46,7 +46,7 @@ PODS:
   - ZappLoginPluginsSDK (8.0.2):
     - Alamofire
     - ZappPlugins
-  - ZappPlugins (9.2.4)
+  - ZappPlugins (9.2.5)
   - ZappPushPluginsSDK (8.0.2):
     - ZappPlugins
 
@@ -81,12 +81,12 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
-  ApplicasterSDK: d98d0a3e02362c645eb2e7474d0b77b0c36d2dc9
+  ApplicasterSDK: 1da8b484c9e8b92b7df55c108d462f938e6154a7
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   FBSDKCoreKit: 5154c35d9058fd7dfa0445ba19e194c4b172fc32
   FBSDKLoginKit: dc98b6bf12334f1a42f28d0457fffc9aa3d1eca5
   FBSDKShareKit: 6f9c622f9a5d051f43f2dab6f753d5198422b89c
-  JWPlayer-SDK: c99b17eb4bda08626569ff91c82caa30bc077e58
+  JWPlayer-SDK: 5dedf5776ca3a4101b6f6574f911f96fd27ab26a
   JWPlayerPlugin: 52cd52bf3de88bc55741b07dfb795649b7de8f21
   PluginPresenter: 1b3d0234c164216dae92b6cd81e79521b929adaa
   SSZipArchive: 1e8e53dcb11bca3ded4738958dc49fc467320a14
@@ -96,7 +96,7 @@ SPEC CHECKSUMS:
   ZappAnalyticsPluginsSDK: 6f8edcddc12ae4001098a3fa6fe87e6fe1a013bd
   ZappGeneralPluginsSDK: 7e91f6030d9f1b81b4781e823b0197bfad351bde
   ZappLoginPluginsSDK: 7afb61fa738f1f73666a8250bd14b5dda8cc8f87
-  ZappPlugins: 054b44992825289d362cf5543ff7ce28e48b346f
+  ZappPlugins: e5ffe70af3d4512746c5911c7582beebd61fa618
   ZappPushPluginsSDK: 2062e2487f3ac877c0ab1a807d1a7f8d357bd333
 
 PODFILE CHECKSUM: bd13c32e3cec6c1325630eeff1bd6c7f57df6d91

--- a/Sport1Player.podspec
+++ b/Sport1Player.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Sport1Player"
-  s.version          = '1.1.2'
+  s.version          = '1.1.3'
   s.summary          = "Sport1Player"
   s.description      = <<-DESC
                         Player for Sport1, based off JWPlayer.

--- a/Sport1Player/Info.plist
+++ b/Sport1Player/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.1.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -16,6 +16,7 @@
 #import "Sport1StreamPlayable.h"
 
 static NSString *const kTrackingInfoKey = @"tracking_info";
+static NSString *const kAgeRatingKey = @"age_rating";
 static NSString *const kFSKKey = @"fsk";
 static NSString *const kPlayableItemsKey = @"playable_items";
 static NSString *const kPluginName = @"pin_validation_plugin_id";
@@ -204,7 +205,7 @@ andPlayerConfiguration:configuration];
 -(void)shouldPresentPinFor:(NSObject <ZPPlayable>*)currentPlayableItem container:(UIView*)container rootViewController:(UIViewController*)rootViewController playerConfiguration:(ZPPlayerConfiguration * _Nullable)configuration {
     NSDictionary *trackingInfo = currentPlayableItem.extensionsDictionary[kTrackingInfoKey];
     
-    if (![trackingInfo.allKeys containsObject:@"age_rating"]) {
+    if (![trackingInfo.allKeys containsObject:kAgeRatingKey]) {
         [self.livestreamPinValidation updateLivestreamAgeData];
         
         if ([self.livestreamPinValidation shouldDisplayPin]) {

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -230,10 +230,10 @@ andPlayerConfiguration:configuration];
     
     NSString *ageString = trackingInfo[kFSKKey];
     int ageRating = 0;
-    if (ageString.length > 0) {
+    if (ageString != nil && ageString.length > 0 && [ageString containsString:@" "]) {
         ageRating = [ageString componentsSeparatedByString:@" "][1].intValue;
     }
-    NSLog(@"[!]: ageRating: %i", ageRating);
+    
     if (ageRating >= kWatershedAge) {
         [self presentPinOn:rootViewController
                  container:container

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -230,8 +230,11 @@ andPlayerConfiguration:configuration];
     
     NSString *ageString = trackingInfo[kFSKKey];
     int ageRating = 0;
-    if (ageString != nil && ageString.length > 0 && [ageString containsString:@" "]) {
-        ageRating = [ageString componentsSeparatedByString:@" "][1].intValue;
+    if (ageString.length > 0 && [ageString containsString:@" "]) {
+        NSArray *splitString = [ageString componentsSeparatedByString:@" "];
+        if (splitString.count > 1) {
+            ageRating = [(NSString*)splitString[1] intValue];
+        }
     }
     
     if (ageRating >= kWatershedAge) {

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -16,7 +16,7 @@
 #import "Sport1StreamPlayable.h"
 
 static NSString *const kTrackingInfoKey = @"tracking_info";
-static NSString *const kAgeRatingKey = @"age_rating";
+static NSString *const kFSKKey = @"fsk";
 static NSString *const kPlayableItemsKey = @"playable_items";
 static NSString *const kPluginName = @"pin_validation_plugin_id";
 static int kWatershedAge = 16;
@@ -204,7 +204,7 @@ andPlayerConfiguration:configuration];
 -(void)shouldPresentPinFor:(NSObject <ZPPlayable>*)currentPlayableItem container:(UIView*)container rootViewController:(UIViewController*)rootViewController playerConfiguration:(ZPPlayerConfiguration * _Nullable)configuration {
     NSDictionary *trackingInfo = currentPlayableItem.extensionsDictionary[kTrackingInfoKey];
     
-    if (![trackingInfo.allKeys containsObject:kAgeRatingKey]) {
+    if (![trackingInfo.allKeys containsObject:@"age_rating"]) {
         [self.livestreamPinValidation updateLivestreamAgeData];
         
         if ([self.livestreamPinValidation shouldDisplayPin]) {
@@ -227,9 +227,13 @@ andPlayerConfiguration:configuration];
         return;
     }
     
-    NSNumber *ageRating = trackingInfo[kAgeRatingKey];
-    
-    if (ageRating.intValue >= kWatershedAge) {
+    NSString *ageString = trackingInfo[kFSKKey];
+    int ageRating = 0;
+    if (ageString.length > 0) {
+        ageRating = [ageString componentsSeparatedByString:@" "][1].intValue;
+    }
+    NSLog(@"[!]: ageRating: %i", ageRating);
+    if (ageRating >= kWatershedAge) {
         [self presentPinOn:rootViewController
                  container:container
        playerConfiguration:configuration
@@ -287,7 +291,7 @@ andPlayerConfiguration:configuration];
 -(void)shouldPresentPin {
     NSDictionary *trackingInfo = self.currentPlayableItem.extensionsDictionary[kTrackingInfoKey];
     
-    if (![trackingInfo.allKeys containsObject:kAgeRatingKey]) {
+    if (![trackingInfo.allKeys containsObject:kFSKKey]) {
         [self.livestreamPinValidation updateLivestreamAgeData];
         
         if ([self.livestreamPinValidation shouldDisplayPin]) {

--- a/Sport1Player/Sport1PlayerLivestreamAge.m
+++ b/Sport1Player/Sport1PlayerLivestreamAge.m
@@ -34,6 +34,7 @@ static NSString *const kLivestreamStart = @"start";
 }
 
 - (void)updateLivestreamAgeData {
+    if (self.livestreamURL.length == 0) {return}
     NSURL *url = [NSURL URLWithString:self.livestreamURL];
     NSData *data = [NSData dataWithContentsOfURL:url];
     NSError *error = nil;

--- a/Sport1Player/Sport1PlayerLivestreamAge.m
+++ b/Sport1Player/Sport1PlayerLivestreamAge.m
@@ -34,7 +34,7 @@ static NSString *const kLivestreamStart = @"start";
 }
 
 - (void)updateLivestreamAgeData {
-    if (self.livestreamURL.length == 0) {return}
+    if (self.livestreamURL.length == 0) {return;}
     NSURL *url = [NSURL URLWithString:self.livestreamURL];
     NSData *data = [NSData dataWithContentsOfURL:url];
     NSError *error = nil;


### PR DESCRIPTION
## Description:

Changing the age rating key from `age_rating` to the correct `fsk`.
Also contains a fix for the plugin crashing when `livesteam_url` was not set

## Known Issues:

### Checklist for this pull request
- [x] PR is scoped to one task
- [ ] Tests included

- One of:
  - [x] The PR is not making any UI change
  - [ ] The PR is making a UI change
    - [ ] Screenshots included

 ## QA:
  - Required test cases:
  - Which apps this change/fix should be tested on:

Thank you!