### PR TITLE
fix(*): Show pin verification if entering foreground

### DIFF
--- a/Sport1Player.podspec
+++ b/Sport1Player.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Sport1Player"
-  s.version          = '1.1.6'
+  s.version          = '1.1.7'
   s.summary          = "Sport1Player"
   s.description      = <<-DESC
                         Player for Sport1, based off JWPlayer.

--- a/Sport1Player.podspec
+++ b/Sport1Player.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Sport1Player"
-  s.version          = '1.1.7'
+  s.version          = '1.2.0'
   s.summary          = "Sport1Player"
   s.description      = <<-DESC
                         Player for Sport1, based off JWPlayer.

--- a/Sport1Player/Info.plist
+++ b/Sport1Player/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.7</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Sport1Player/Info.plist
+++ b/Sport1Player/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.6</string>
+	<string>1.1.7</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -21,6 +21,7 @@ static NSString *const kPlayableItemsKey = @"playable_items";
 static NSString *const kPluginName = @"pin_validation_plugin_id";
 static NSString *const kTokenName = @"stream_token";
 static NSString *const kNameSpace = @"InPlayer.v1";
+static NSString *const kFSK16 = @"FSK16";
 
 @interface Sport1PlayerAdapter ()
 @property (nonatomic, strong) Sport1PlayerLivestreamPin *livestreamPinValidation;
@@ -245,7 +246,7 @@ andPlayerConfiguration:configuration];
     // Is not a live stream
     NSString *ageString = trackingInfo[kFSKKey];
     if ((id)ageString != [NSNull null]) {
-        if ([ageString isEqualToString:@"FSK16"]) {
+        if ([ageString isEqualToString:kFSK16]) {
             [self presentPinOn:rootViewController
                      container:container
            playerConfiguration:configuration

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -47,7 +47,17 @@ static int kWatershedAge = 16;
     instance.currentPlayableItem = items.firstObject;
     instance.currentPlayableItems = items;
     
+    [[NSNotificationCenter defaultCenter] addObserver:instance
+                                             selector:@selector(applicationWillEnterForegroundNotificationHandler)
+                                                 name:UIApplicationWillEnterForegroundNotification
+                                               object:nil];
+    
     return instance;
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 #pragma mark - Livestream
 -(void)createLivestreamPinCheck {
@@ -329,6 +339,10 @@ andPlayerConfiguration:configuration];
                                                                          andAmendedURL:amendedURL];
         return amended;
     } else {return current;}
+}
+#pragma mark - Handlers
+-(void)applicationWillEnterForegroundNotificationHandler {
+    [self shouldPresentPin];
 }
 
 @end

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -21,7 +21,6 @@ static NSString *const kPlayableItemsKey = @"playable_items";
 static NSString *const kPluginName = @"pin_validation_plugin_id";
 static NSString *const kTokenName = @"stream_token";
 static NSString *const kNameSpace = @"InPlayer.v1";
-static int kWatershedAge = 16;
 
 @interface Sport1PlayerAdapter ()
 @property (nonatomic, strong) Sport1PlayerLivestreamPin *livestreamPinValidation;
@@ -246,14 +245,7 @@ andPlayerConfiguration:configuration];
     // Is not a live stream
     NSString *ageString = trackingInfo[kFSKKey];
     if ((id)ageString != [NSNull null]) {
-        int ageRating = 0;
-        if (ageString.length > 0 && [ageString containsString:@" "]) {
-            NSArray *splitString = [ageString componentsSeparatedByString:@" "];
-            if (splitString.count > 1) {
-                ageRating = [(NSString*)splitString[1] intValue];
-            }
-        }
-        if (ageRating >= kWatershedAge) {
+        if ([ageString isEqualToString:@"FSK16"]) {
             [self presentPinOn:rootViewController
                      container:container
            playerConfiguration:configuration

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -12,7 +12,7 @@
   "platform": "ios",
   "author_name": "Oliver Stowell",
   "author_email": "o.stowell@applicaster.co.uk",
-  "manifest_version": "1.1.6",
+  "manifest_version": "1.1.7",
   "name": "Sport1 Player",
   "description": "Sport1 wrapper for JWPlayer",
   "type": "player",
@@ -20,7 +20,7 @@
   "identifier": "sport1player",
   "ui_builder_support": true,
   "dependency_name": "Sport1Player",
-  "dependency_version": "1.1.6",
+  "dependency_version": "1.1.7",
   "whitelisted_account_ids": [
     "5d1b6753564117000de4bb60"
   ],

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -12,7 +12,7 @@
   "platform": "ios",
   "author_name": "Oliver Stowell",
   "author_email": "o.stowell@applicaster.co.uk",
-  "manifest_version": "1.1.7",
+  "manifest_version": "1.2.0",
   "name": "Sport1 Player",
   "description": "Sport1 wrapper for JWPlayer",
   "type": "player",
@@ -20,7 +20,7 @@
   "identifier": "sport1player",
   "ui_builder_support": true,
   "dependency_name": "Sport1Player",
-  "dependency_version": "1.1.7",
+  "dependency_version": "1.2.0",
   "whitelisted_account_ids": [
     "5d1b6753564117000de4bb60"
   ],


### PR DESCRIPTION
## Description:

If the player is open when the app enters the foreground, it should display the pin verification plugin if needed.
Also corrects the VOD age restriction check.

## Known Issues:

### Checklist for this pull request
- [x] PR is scoped to one task
- [ ] Tests included

- One of:
  - [x] The PR is not making any UI change
  - [ ] The PR is making a UI change
    - [ ] Screenshots included

 ## QA:
  - Required test cases:
  - Which apps this change/fix should be tested on:

Thank you!