### PR TITLE
fix(*): Pin Verification only re-displays if player is visible

### DIFF
--- a/Sport1Player.podspec
+++ b/Sport1Player.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Sport1Player"
-  s.version          = '1.2.0'
+  s.version          = '1.2.1'
   s.summary          = "Sport1Player"
   s.description      = <<-DESC
                         Player for Sport1, based off JWPlayer.

--- a/Sport1Player/Info.plist
+++ b/Sport1Player/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -306,7 +306,8 @@ andPlayerConfiguration:configuration];
 #pragma mark - Livestream Pin Presentation
 -(void)shouldPresentPin {
     [self.livestreamPinValidation updateLivestreamAgeDataWithCompletion:^(BOOL success) {
-        if (success) {
+        //Check if player is visible
+        if (success && self.playerViewController.viewIfLoaded.window != nil) {
             [[NSOperationQueue mainQueue] addOperationWithBlock:^{
                 if ([self.livestreamPinValidation shouldDisplayPin]) {
                     [self presentPinOn:self.playerViewController

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -12,7 +12,7 @@
   "platform": "ios",
   "author_name": "Oliver Stowell",
   "author_email": "o.stowell@applicaster.co.uk",
-  "manifest_version": "1.2.0",
+  "manifest_version": "1.2.1",
   "name": "Sport1 Player",
   "description": "Sport1 wrapper for JWPlayer",
   "type": "player",
@@ -20,7 +20,7 @@
   "identifier": "sport1player",
   "ui_builder_support": true,
   "dependency_name": "Sport1Player",
-  "dependency_version": "1.2.0",
+  "dependency_version": "1.2.1",
   "whitelisted_account_ids": [
     "5d1b6753564117000de4bb60"
   ],


### PR DESCRIPTION
## Description:

Player adapter now checks if the view controller is visible, and then displays the pin verification.

## Known Issues:

### Checklist for this pull request
- [x] PR is scoped to one task
- [ ] Tests included

- One of:
  - [x] The PR is not making any UI change
  - [ ] The PR is making a UI change
    - [ ] Screenshots included

 ## QA:
  - Required test cases:
  - Which apps this change/fix should be tested on:

Thank you!