### PR TITLE
fix(*): Change livestream pin

### DIFF
--- a/Sport1Player.podspec
+++ b/Sport1Player.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Sport1Player"
-  s.version          = '1.2.1'
+  s.version          = '1.3.0'
   s.summary          = "Sport1Player"
   s.description      = <<-DESC
                         Player for Sport1, based off JWPlayer.

--- a/Sport1Player/Info.plist
+++ b/Sport1Player/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -21,7 +21,6 @@ static NSString *const kPlayableItemsKey = @"playable_items";
 static NSString *const kPluginName = @"pin_validation_plugin_id";
 static NSString *const kTokenName = @"stream_token";
 static NSString *const kNameSpace = @"InPlayer.v1";
-static NSString *const kFSK16 = @"FSK16";
 
 @interface Sport1PlayerAdapter ()
 @property (nonatomic, strong) Sport1PlayerLivestreamPin *livestreamPinValidation;

--- a/Sport1Player/Sport1PlayerLivestreamAge.h
+++ b/Sport1Player/Sport1PlayerLivestreamAge.h
@@ -12,6 +12,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const kFSKKey = @"fsk";
+static NSString *const kFSK16 = @"FSK16";
 
 @interface Sport1PlayerLivestreamPin : NSObject
 

--- a/Sport1Player/Sport1PlayerLivestreamAge.m
+++ b/Sport1Player/Sport1PlayerLivestreamAge.m
@@ -9,8 +9,6 @@
 #import "Sport1PlayerLivestreamAge.h"
 
 static NSString *const kLivestreamURL = @"livestream_url";
-static NSString *const kAgeRestrictionEnd = @"ageRestrictionEnd";
-static NSString *const kAgeRestrictionStart = @"ageRestrictionStart";
 static NSString *const kEPG = @"epg";
 static NSString *const kLivestreamEnd = @"end";
 static NSString *const kLivestreamStart = @"start";
@@ -18,9 +16,8 @@ static NSString *const kLivestreamStart = @"start";
 @interface Sport1PlayerLivestreamPin ()
 @property (nonatomic, strong) NSTimer *timer;
 @property (nonatomic, strong) NSString *livestreamURL;
-@property (nonatomic) NSDate *ageRestrictionEnd;
-@property (nonatomic) NSDate *ageRestrictionStart;
 @property (nonatomic) NSDate *livestreamEnd;
+@property (nonatomic) BOOL ageRestricted;
 @end
 
 @implementation Sport1PlayerLivestreamPin
@@ -65,15 +62,12 @@ static NSString *const kLivestreamStart = @"start";
     }
     if (livestreamJSON == nil) {return;}
     
-    NSNumber *restrictionEnd = livestreamJSON[kAgeRestrictionEnd];
-    NSNumber *restrictionStart = livestreamJSON[kAgeRestrictionStart];
-    
-    self.ageRestrictionEnd = [NSDate dateWithTimeIntervalSince1970:restrictionEnd.intValue];
-    self.ageRestrictionStart = [NSDate dateWithTimeIntervalSince1970:restrictionStart.intValue];
-    
     NSDictionary *current = [self currentLivestreamFromJSON:livestreamJSON];
     if (current) {
         self.livestreamEnd = [self dateFromString:current[kLivestreamEnd]];
+        
+        if ([current.allKeys containsObject:kFSKKey]) {self.ageRestricted = YES;}
+        else {self.ageRestricted = NO;}
         
         if (self.timer != nil) {
             [self.timer invalidate];
@@ -121,11 +115,7 @@ static NSString *const kLivestreamStart = @"start";
 }
 
 -(BOOL)shouldDisplayPin {
-    NSDate *now = [NSDate date];
-    if ([self.ageRestrictionEnd compare:now] == NSOrderedDescending &&
-        [self.ageRestrictionStart compare:now] == NSOrderedAscending) {
-        return YES;
-    } else { return NO; }
+    return self.ageRestricted;
 }
 
 @end

--- a/Sport1Player/Sport1PlayerLivestreamAge.m
+++ b/Sport1Player/Sport1PlayerLivestreamAge.m
@@ -41,7 +41,11 @@ static NSString *const kLivestreamStart = @"start";
                                                                  completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
                                                                      if (error != nil) {
                                                                          NSLog(@"<ERROR>Sport1Player: %@", error.localizedDescription);
-                                                                         completionHandler(NO);
+                                                                         NSLog(@"Retrying connection");
+                                                                         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                                                                             [self updateLivestreamAgeDataWithCompletion:completionHandler];
+                                                                         });
+                                                                         return;
                                                                      }
                                                                      
                                                                      [[NSOperationQueue mainQueue] addOperationWithBlock:^{
@@ -66,8 +70,11 @@ static NSString *const kLivestreamStart = @"start";
     if (current) {
         self.livestreamEnd = [self dateFromString:current[kLivestreamEnd]];
         
-        if ([current.allKeys containsObject:kFSKKey]) {self.ageRestricted = YES;}
-        else {self.ageRestricted = NO;}
+        if ([current.allKeys containsObject:kFSKKey]) {
+            if ([[current[kFSKKey] stringByReplacingOccurrencesOfString:@" " withString:@""] isEqualToString:kFSK16]) {
+                self.ageRestricted = YES;
+            } else {self.ageRestricted = NO;}
+        } else {self.ageRestricted = NO;}
         
         if (self.timer != nil) {
             [self.timer invalidate];

--- a/Sport1Player/Sport1PlayerLivestreamAge.m
+++ b/Sport1Player/Sport1PlayerLivestreamAge.m
@@ -76,7 +76,7 @@ static NSString *const kLivestreamStart = @"start";
     NSDictionary *current = [self currentLivestreamFromJSON:livestreamJSON];
     if (current) {
         self.nextLivestream = [self livestreamFromJSON:livestreamJSON
-                                             withStart:current[kLivestreamStart]];
+                                             withStart:current[kLivestreamEnd]];
         self.livestreamEnd = [self dateFromString:current[kLivestreamEnd]];
         
         [self updateAgeRestriction:current];

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -12,7 +12,7 @@
   "platform": "ios",
   "author_name": "Oliver Stowell",
   "author_email": "o.stowell@applicaster.co.uk",
-  "manifest_version": "1.2.1",
+  "manifest_version": "1.3.0",
   "name": "Sport1 Player",
   "description": "Sport1 wrapper for JWPlayer",
   "type": "player",
@@ -20,7 +20,7 @@
   "identifier": "sport1player",
   "ui_builder_support": true,
   "dependency_name": "Sport1Player",
-  "dependency_version": "1.2.1",
+  "dependency_version": "1.3.0",
   "whitelisted_account_ids": [
     "5d1b6753564117000de4bb60"
   ],


### PR DESCRIPTION
## Description:

Changes the live stream age check to the `fsk` key rather than the age restriction start & end values.

## Known Issues:

### Checklist for this pull request
- [x] PR is scoped to one task
- [ ] Tests included

- One of:
  - [x] The PR is not making any UI change
  - [ ] The PR is making a UI change
    - [ ] Screenshots included

 ## QA:
  - Required test cases:
  - Which apps this change/fix should be tested on:

Thank you!