### PR TITLE
Fix(*): Pin from background was checking next livestream

### DIFF
--- a/Sport1Player.podspec
+++ b/Sport1Player.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Sport1Player"
-  s.version          = '1.5.0'
+  s.version          = '1.5.1'
   s.summary          = "Sport1Player"
   s.description      = <<-DESC
                         Player for Sport1, based off JWPlayer.
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
                   }
 
   #Using ZappPlugins 9.1.0 until JWPlayerPlugin 3.2.3 is updated.
-  s.dependency 'ZappPlugins', '~> 9.1'
+  s.dependency 'ZappPlugins'
   s.dependency 'JWPlayerPlugin'
   s.dependency 'PluginPresenter'
 

--- a/Sport1Player/Info.plist
+++ b/Sport1Player/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.5.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Sport1Player/Sport1PlayerAdapter.m
+++ b/Sport1Player/Sport1PlayerAdapter.m
@@ -321,6 +321,7 @@ andPlayerConfiguration:configuration];
         if (success && self.playerViewController.viewIfLoaded.window != nil) {
             [[NSOperationQueue mainQueue] addOperationWithBlock:^{
                 if ([self.livestreamPinValidation shouldDisplayPin]) {
+                    [self.playerViewController pause];
                     [self presentPinOn:self.playerViewController
                              container:self.container
                    playerConfiguration:self.playerConfiguration

--- a/Sport1Player/Sport1PlayerLivestreamAge.m
+++ b/Sport1Player/Sport1PlayerLivestreamAge.m
@@ -38,6 +38,8 @@ static NSString *const kLivestreamStart = @"start";
         [self updateAgeRestriction:self.nextLivestream];
         completionHandler(YES);
         ranCompletion = YES;
+    } else {
+        self.ageRestricted = NO;
     }
     NSURL *url = [NSURL URLWithString:self.livestreamURL];
     

--- a/Sport1Player/Sport1PlayerLivestreamAge.m
+++ b/Sport1Player/Sport1PlayerLivestreamAge.m
@@ -34,7 +34,8 @@ static NSString *const kLivestreamStart = @"start";
 -(void)updateLivestreamAgeDataWithCompletion:(void (^)(BOOL success))completionHandler {
     if (self.livestreamURL.length == 0) {completionHandler(NO);}
     BOOL ranCompletion = NO;
-    if (self.nextLivestream != nil) {
+    NSDate *now = [NSDate date];
+    if (self.nextLivestream != nil && [self isCurrent:self.nextLivestream withNow:now]) {
         [self updateAgeRestriction:self.nextLivestream];
         completionHandler(YES);
         ranCompletion = YES;
@@ -116,17 +117,23 @@ static NSString *const kLivestreamStart = @"start";
     NSDate *now = [NSDate date];
     
     for (NSDictionary *livestream in epg) {
-        NSDate *start = [self dateFromString:livestream[kLivestreamStart]];
-        NSDate *end = [self dateFromString:livestream[kLivestreamEnd]];
-        
-        if ([end compare:now] == NSOrderedDescending &
-            [start compare:now] == NSOrderedAscending) {
-            NSLog(@"[!]: currentEnd: %@", end);
-            return livestream;
-        }
+        if ([self isCurrent:livestream withNow:now]) {return livestream;}
     }
     
     return nil;
+}
+
+-(BOOL)isCurrent:(NSDictionary*)livestream withNow:(NSDate*)now {
+    NSDate *start = [self dateFromString:livestream[kLivestreamStart]];
+    NSDate *end = [self dateFromString:livestream[kLivestreamEnd]];
+    
+    if ([end compare:now] == NSOrderedDescending &
+        [start compare:now] == NSOrderedAscending) {
+        NSLog(@"[!]: currentEnd: %@", end);
+        return YES;
+    } else {
+        return NO;
+    }
 }
 
 -(NSDictionary* _Nullable)livestreamFromJSON:(NSDictionary*)livestreamJSON withStart:(NSString*)start {


### PR DESCRIPTION
## Description:

When returning from the background, the next live-stream was being checked even if it's not the current one displayed.

## Known Issues:

### Checklist for this pull request
- [x] PR is scoped to one task
- [ ] Tests included

- One of:
  - [x] The PR is not making any UI change
  - [ ] The PR is making a UI change
    - [ ] Screenshots included

 ## QA:
  - Required test cases:
  - Which apps this change/fix should be tested on:

Thank you!